### PR TITLE
asoc: codecs: import missing Mido Specific change

### DIFF
--- a/techpack/audio/asoc/codecs/wcd-mbhc-v2.c
+++ b/techpack/audio/asoc/codecs/wcd-mbhc-v2.c
@@ -1219,7 +1219,7 @@ static irqreturn_t wcd_mbhc_release_handler(int irq, void *data)
 	if (mbhc->mbhc_detection_logic == WCD_DETECTION_LEGACY &&
 		mbhc->current_plug == MBHC_PLUG_TYPE_HEADPHONE) {
 		wcd_mbhc_find_plug_and_report(mbhc, MBHC_PLUG_TYPE_HEADSET);
-#ifdef CONFIG_MACH_XIAOMI_TISSOT
+#if (defined CONFIG_MACH_XIAOMI_TISSOT) || (defined CONFIG_MACH_XIAOMI_MIDO)
 		wcd_mbhc_jack_report(mbhc, &mbhc->headset_jack,
 				0, WCD_MBHC_JACK_MASK);
 		msleep(100);


### PR DESCRIPTION
referenced from https://github.com/MiCode/Xiaomi_Kernel_OpenSource/commit/e12ec432a9ef867a3602a8e63322bc6b7aabcfd2