### PR TITLE
dts: msm8953-pinctrl invalid group fix

### DIFF
--- a/arch/arm64/boot/dts/qcom/mido/msm8953-pinctrl-mido.dtsi
+++ b/arch/arm64/boot/dts/qcom/mido/msm8953-pinctrl-mido.dtsi
@@ -16,7 +16,7 @@
 		goodix_spi_active: goodix_spi_active{
                         mux {
                                 pins = "gpio135", "gpio136", "gpio137", "gpio138";
-                                function = "blsp_spi6";
+                                function = "blsp_spi7";
                         };
                         config {
                                 pins = "gpio135", "gpio136", "gpio137", "gpio138";


### PR DESCRIPTION
GPIO_135 GPIO_136 GPIO_137 GPIO_138 all these gpio's belong to blsp_spi7.
While fpc already has correct group configuration , Fixing it for goodix 
Hence fixes :
-------gf_init start.--------
[ 2.436057] msm8953-pinctrl 1000000.pinctrl: invalid group "gpio135" for function "blsp_spi6"
[ 2.436075] msm8953-pinctrl 1000000.pinctrl: invalid group "gpio136" for function "blsp_spi6"
[ 2.436093] msm8953-pinctrl 1000000.pinctrl: invalid group "gpio137" for function "blsp_spi6"
[ 2.436110] msm8953-pinctrl 1000000.pinctrl: invalid group "gpio138" for function "blsp_spi6"